### PR TITLE
Fixed warning because using deprecated filter FHEE__EE_Export__report_registrations__reg_csv_array

### DIFF
--- a/EED_Promotions.module.php
+++ b/EED_Promotions.module.php
@@ -112,13 +112,13 @@ class EED_Promotions extends EED_Module
             2
         );
         // the filter got renamed and the old one was deprecated.
-        if(version_compare(
+        if (version_compare(
             espresso_version(),
             '4.9.69.p',
             '>'
-        )){
+        )) {
             $filter_name = 'FHEE__EventEspressoBatchRequest__JobHandlers__RegistrationsReport__reg_csv_array';
-        } else{
+        } else {
             $filter_name = 'FHEE__EE_Export__report_registrations__reg_csv_array';
         }
         add_filter(

--- a/EED_Promotions.module.php
+++ b/EED_Promotions.module.php
@@ -111,8 +111,18 @@ class EED_Promotions extends EED_Module
             10,
             2
         );
+        // the filter got renamed and the old one was deprecated.
+        if(version_compare(
+            espresso_version(),
+            '4.9.69.p',
+            '>'
+        )){
+            $filter_name = 'FHEE__EventEspressoBatchRequest__JobHandlers__RegistrationsReport__reg_csv_array';
+        } else{
+            $filter_name = 'FHEE__EE_Export__report_registrations__reg_csv_array';
+        }
         add_filter(
-            'FHEE__EE_Export__report_registrations__reg_csv_array',
+            $filter_name,
             array( 'EED_Promotions', 'add_promotions_column_to_reg_csv_report' ),
             10,
             2


### PR DESCRIPTION

<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
We will be deprecating the filter FHEE__EE_Export__report_registrations__reg_csv_array soon, so we should stop using it in this add-on too.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [ ] Create a registrations csv report using EE core master (4.9.68.p or lower) and this branch active. The promotions column should still appear
* [ ] Change EE core to branch  ENH/remove-square-brackets-in-csv-column-names (or 4.9.70.p or higher), and pretend the version is even higher by changing the EE core version to 4.9.90.p. The warning should not appear (whereas with promotions master branch it would)

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
