### PR TITLE
Added new indexes for commonly queried fields

### DIFF
--- a/core/data_migration_scripts/EE_DMS_Promotions_1_0_0.dms.php
+++ b/core/data_migration_scripts/EE_DMS_Promotions_1_0_0.dms.php
@@ -75,7 +75,10 @@ class EE_DMS_Promotions_1_0_0 extends EE_Data_Migration_Script_Base
                 PRO_deleted tinyint(1) NOT NULL DEFAULT 0,
                 PRO_wp_user bigint(20) unsigned NOT NULL DEFAULT 1,
                 PRIMARY KEY  (PRO_ID),
-                KEY PRC_ID (PRC_ID)",
+                KEY PRC_ID (PRC_ID),
+                KEY PRO_code (PRO_code),
+                KEY PRO_start (PRO_start),
+                KEY PRO_end (PRO_end)",
             'ENGINE=InnoDB'
         );
 


### PR DESCRIPTION
## Problem this Pull Request solves
while working on https://github.com/eventespresso/EE4-Promotions/issues/6 I noticed that there were a lot of promotions related queries made that utilized the `PRO_code`, `PRO_start`, and `PRO_end` fields but that there were no indexes for those fields on the `esp_promotion` table.

The work in this branch adds indexes for those fields.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
