### PR TITLE
Ensure we check the var before using it

### DIFF
--- a/EED_Promotions.module.php
+++ b/EED_Promotions.module.php
@@ -532,6 +532,11 @@ class EED_Promotions extends EED_Module
     {
         add_action('wp_enqueue_scripts', array( $this, 'enqueue_scripts' ));
         EE_Registry::instance()->load_helper('HTML');
+
+        $singular_label = isset($this->config()->label->singular) ?
+            $this->config()->label->singular :
+            esc_html__('Promotion Code', 'event_espresso');
+
         $before_payment_options->add_subsections(
             array(
                 'promotions_form' => new EE_Form_Section_Proper(
@@ -546,7 +551,7 @@ class EED_Promotions extends EED_Module
                                     'html_name'       => 'ee_promotion_code_input',
                                     'html_label_text' => apply_filters(
                                         'FHEE__EED_Promotions___add_promotions_form_inputs__ee_promotion_code_input__html_label_text',
-                                        EEH_HTML::h4($this->config()->label->singular)
+                                        EEH_HTML::h4($singular_label)
                                     ),
                                 )
                             ),
@@ -556,12 +561,7 @@ class EED_Promotions extends EED_Module
                                     'html_name' => 'ee_promotion_code_submit',
                                     'default'   => apply_filters(
                                         'FHEE__EED_Promotions___add_promotions_form_inputs__ee_promotion_code_submit__default',
-                                        sprintf(
-                                            esc_html__('Submit %s', 'event_espresso'),
-                                            $this->config()->label->singular ?
-                                            $this->config()->label->singular :
-                                            esc_html__('Promotion Code', 'event_espresso')
-                                        )
+                                        sprintf(esc_html__('Submit %s', 'event_espresso'), $singular_label)
                                     ),
                                 )
                             ),


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Solves the errors at https://github.com/eventespresso/EE4-Promotions/issues/17

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
With EE4 Promotions activated:

- Register for an event that has a promotion activated
- At Payment page, the Promotion Code section should display the label "Promotion Code" and the button "Submit Promotion Code" normally.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
