### PR TITLE
Only display code inputs when active promos are appliable

### DIFF
--- a/EED_Promotions.module.php
+++ b/EED_Promotions.module.php
@@ -522,6 +522,70 @@ class EED_Promotions extends EED_Module
 
 
     /**
+     *    _has_active_promotions_at_cart
+     *
+     * @access private
+     * @return bool
+     */
+    private function _has_active_promotions_at_cart()
+    {
+        // controls how many active promotions we have for events in the Cart.
+        $has_active_promotions = false;
+        // get current Cart instance to get events from.
+        $cart = EE_Registry::instance()->SSN->cart();
+
+        if ($cart instanceof EE_Cart) {
+            // get all events.
+            $events = $this->get_events_from_cart($cart);
+
+            // if we got events...
+            if (!empty($events)) {
+                $EEM_Promotion = EE_Registry::instance()->load_model('Promotion');
+                $active_promotions = $EEM_Promotion->get_all_active_code_promotions();
+
+                // loop through all the events.
+                foreach ($events as $event) {
+                    // stop the loop if we already got a promotion.
+                    if ($has_active_promotions) {
+                        break;
+                    }
+
+                    foreach ($active_promotions as $promotion) {
+                        // stop the loop if we already got a promotion.
+                        if ($has_active_promotions) {
+                            break;
+                        }
+
+                        if ($promotion instanceof EE_Promotion) {
+                            // get all promotion objects that can still be redeemed
+                            $redeemable_scope_promos = $promotion->scope_obj()->get_redeemable_scope_promos(
+                                $promotion,
+                                true,
+                                $event
+                            );
+                            foreach ($redeemable_scope_promos as $scope => $promo_obj_IDs) {
+                                // stop the loop if we already got a promotion.
+                                if ($has_active_promotions) {
+                                    break;
+                                }
+
+                                // Check if the active promotion applies to the event.
+                                if ($scope === 'Event' && in_array($event->ID(), $promo_obj_IDs)) {
+                                    // We found an active promotion.
+                                    $has_active_promotions = true;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return $has_active_promotions;
+    }
+
+
+    /**
      *    _add_promotions_form_inputs
      *
      * @access        private
@@ -530,6 +594,14 @@ class EED_Promotions extends EED_Module
      */
     private function _add_promotions_form_inputs($before_payment_options)
     {
+        // Checks if any promotion applies to current cart.
+        $has_active_promotions = $this->_has_active_promotions_at_cart();
+
+        // If no active promotions are found, we do not display the section field.
+        if (!$has_active_promotions) {
+            return $before_payment_options;
+        }
+
         add_action('wp_enqueue_scripts', array( $this, 'enqueue_scripts' ));
         EE_Registry::instance()->load_helper('HTML');
         $before_payment_options->add_subsections(

--- a/EED_Promotions.module.php
+++ b/EED_Promotions.module.php
@@ -522,11 +522,11 @@ class EED_Promotions extends EED_Module
 
 
     /**
-     *    hasActivePromotionsAtCart
+     *    hasApplicablePromotionsAtCart
      *
      * @return bool
      */
-    private function hasActivePromotionsAtCart()
+    private function hasApplicablePromotionsAtCart()
     {
         // get current Cart instance to get events from.
         $cart = EE_Registry::instance()->SSN->cart();
@@ -540,7 +540,8 @@ class EED_Promotions extends EED_Module
                     [
                         'PRO_scope'               => 'Event',
                         'Promotion_Object.OBJ_ID' => ['in', array_keys($events)],
-                    ]
+                    ],
+                    'limit' => 1,
                 ]);
                 return ! empty($active_promotions);
             }
@@ -559,17 +560,17 @@ class EED_Promotions extends EED_Module
     private function _add_promotions_form_inputs($before_payment_options)
     {
         // flag controlling either active promos should be checked.
-        $check_for_active_promotions = apply_filters(
-            'FHEE__EED_Promotions___add_promotions_form_inputs__checkForActivePromotions',
+        $check_for_applicable_promotions = apply_filters(
+            'FHEE__EED_Promotions___add_promotions_form_inputs__checkForApplicablePromotions',
             true
         );
 
-        if ($check_for_active_promotions) {
+        if ($check_for_applicable_promotions) {
             // checks if any promotion applies to current cart.
-            $has_active_promotions = $this->hasActivePromotionsAtCart();
+            $has_applicable_promotions = $this->hasApplicablePromotionsAtCart();
 
             // if no active promotions are found, we do not display the section field.
-            if (!$has_active_promotions) {
+            if (!$has_applicable_promotions) {
                 return $before_payment_options;
             }
         }

--- a/EED_Promotions.module.php
+++ b/EED_Promotions.module.php
@@ -522,45 +522,30 @@ class EED_Promotions extends EED_Module
 
 
     /**
-     *    _hasActivePromotionsAtCart
+     *    hasActivePromotionsAtCart
      *
-     * @access private
      * @return bool
      */
-    private function _hasActivePromotionsAtCart()
+    private function hasActivePromotionsAtCart()
     {
-        // controls how many active promotions we have for events in the Cart.
-        $has_active_promotions = false;
         // get current Cart instance to get events from.
         $cart = EE_Registry::instance()->SSN->cart();
-
         if ($cart instanceof EE_Cart) {
             // get all events.
             $events = $this->get_events_from_cart($cart);
-
-            // store the event IDs.
-            $event_ids = [];
-
             // if we got events...
-            if (!empty($events)) {
-                // loop through all the events.
-                foreach ($events as $event) {
-                    $event_ids[] = $event->ID();
-                }
-                
+            if (! empty($events)) {
                 $EEM_Promotion = EE_Registry::instance()->load_model('Promotion');
-                $active_promotions = $EEM_Promotion->getAllActiveCodePromotions([[
-                    'PRO_scope'               => 'Event',
-                    'Promotion_Object.OBJ_ID' => [ 'in', $event_ids ],
-                ]]);
-
-                if (count($active_promotions) > 0) {
-                    $has_active_promotions = true;
-                }
+                $active_promotions = $EEM_Promotion->getAllActiveCodePromotions([
+                    [
+                        'PRO_scope'               => 'Event',
+                        'Promotion_Object.OBJ_ID' => ['in', array_keys($events)],
+                    ]
+                ]);
+                return ! empty($active_promotions);
             }
         }
-
-        return $has_active_promotions;
+        return false;
     }
 
 
@@ -581,7 +566,7 @@ class EED_Promotions extends EED_Module
 
         if ($check_for_active_promotions) {
             // checks if any promotion applies to current cart.
-            $has_active_promotions = $this->_hasActivePromotionsAtCart();
+            $has_active_promotions = $this->hasActivePromotionsAtCart();
 
             // if no active promotions are found, we do not display the section field.
             if (!$has_active_promotions) {

--- a/EED_Promotions.module.php
+++ b/EED_Promotions.module.php
@@ -522,7 +522,7 @@ class EED_Promotions extends EED_Module
 
 
     /**
-     *    _has_active_promotions_at_cart
+     *    _hasActivePromotionsAtCart
      *
      * @access private
      * @return bool

--- a/core/db_models/EEM_Promotion.model.php
+++ b/core/db_models/EEM_Promotion.model.php
@@ -124,6 +124,37 @@ class EEM_Promotion extends EEM_Soft_Delete_Base
 
 
     /**
+     * get_all_active_code_promotions
+     * retrieves all promotions that are currently active based on the current time and do
+     * utilize a code
+     *
+     * Note this DOES include promotions that have no dates set.
+     *
+     * @param array  $query_params
+     * @return EE_Promotion[]
+     */
+    public function get_all_active_code_promotions($query_params = array())
+    {
+
+        return $this->get_all(
+            array_replace_recursive(
+                array(
+                    array(
+                        'PRO_code'      => [ '!=', null ],
+                        'PRO_deleted'   => false,
+                    )
+                ),
+                // query params for calendar controlled expiration
+                $this->_get_promotion_expiration_query_params(),
+                // incoming $query_params array filtered to remove null values and empty strings
+                array_filter((array) $query_params, 'EEM_Promotion::has_value')
+            )
+        );
+    }
+
+
+
+    /**
      * _get_promotion_expiration_query_params
      * query params for calendar controlled expiration
      *

--- a/core/db_models/EEM_Promotion.model.php
+++ b/core/db_models/EEM_Promotion.model.php
@@ -124,7 +124,7 @@ class EEM_Promotion extends EEM_Soft_Delete_Base
 
 
     /**
-     * get_all_active_code_promotions
+     * getAllActiveCodePromotions
      * retrieves all promotions that are currently active based on the current time and do
      * utilize a code
      *
@@ -133,7 +133,7 @@ class EEM_Promotion extends EEM_Soft_Delete_Base
      * @param array  $query_params
      * @return EE_Promotion[]
      */
-    public function get_all_active_code_promotions($query_params = array())
+    public function getAllActiveCodePromotions($query_params = array())
     {
 
         return $this->get_all(


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Solves => https://github.com/eventespresso/EE4-Promotions/issues/5 - where the Promotion Code input at Checkout will be displayed ONLY if an active promotion can be applied to the events on the cart.

Else, the discount code field will be hidden.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

Two situations should be tested:

- If you checkout with at least one ticket that has at least one active promotion that uses code, the Promotion Code input should appear.

- If you checkout with  at least one ticket that has NO active promotion that uses code, the Promotion Code input won't be displayed.

Besides that, documentation might be affected - since this feature can be turned off (and Promotion Code input will always be displayed) with the following new filter:

```
        // flag controlling either active promos should be checked.
        $check_for_active_promotions = apply_filters(
            'FHEE__EED_Promotions___add_promotions_form_inputs__checkForApplicablePromotions',
            true
        );
```
## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
