### PR TITLE
Ensure Promo Code field appears on checkout revisit and with global code

### DIFF
--- a/EED_Promotions.module.php
+++ b/EED_Promotions.module.php
@@ -530,6 +530,10 @@ class EED_Promotions extends EED_Module
     {
         // get current Cart instance to get events from.
         $cart = EE_Registry::instance()->SSN->cart();
+        // if we didn't get an instance ofEE_Cart from SSN, try pulling it from EE_Checkout.
+        if (!$cart instanceof EE_Cart) {
+            $cart = EE_Registry::instance()->SSN->checkout()->cart;
+        }
         if ($cart instanceof EE_Cart) {
             // get all events.
             $events = $this->get_events_from_cart($cart);

--- a/EED_Promotions.module.php
+++ b/EED_Promotions.module.php
@@ -533,20 +533,34 @@ class EED_Promotions extends EED_Module
         if ($cart instanceof EE_Cart) {
             // get all events.
             $events = $this->get_events_from_cart($cart);
-            // if we got events...
+            // if we got any global event...
             if (! empty($events)) {
                 $EEM_Promotion = EE_Registry::instance()->load_model('Promotion');
+                // check if we got any global event.
                 $active_promotions = $EEM_Promotion->getAllActiveCodePromotions([
                     [
-                        'PRO_scope' => 'Event',
-                        'OR' => [
-                            'Promotion_Object.OBJ_ID' => ['in', array_keys($events)],
-                            'PRO_global'              => true,
-                        ],
+                        'PRO_scope'  => 'Event',
+                        'PRO_global' => true,
                     ],
                     'limit' => 1,
                 ]);
-                return ! empty($active_promotions);
+
+                $has_active_promotions = ! empty($active_promotions);
+
+                // if not, we check if we have for that specific event.
+                if (! $has_active_promotions) {
+                    $active_promotions = $EEM_Promotion->getAllActiveCodePromotions([
+                        [
+                            'PRO_scope' => 'Event',
+                            'Promotion_Object.OBJ_ID' => ['in', array_keys($events)],
+                        ],
+                        'limit' => 1,
+                    ]);
+
+                    $has_active_promotions = ! empty($active_promotions);
+                }
+
+                return $has_active_promotions;
             }
         }
         return false;

--- a/EED_Promotions.module.php
+++ b/EED_Promotions.module.php
@@ -533,39 +533,29 @@ class EED_Promotions extends EED_Module
         if ($cart instanceof EE_Cart) {
             // get all events.
             $events = $this->get_events_from_cart($cart);
-            // if we got any global event...
+            // if we got events...
             if (! empty($events)) {
                 $EEM_Promotion = EE_Registry::instance()->load_model('Promotion');
-                // check if we got any global event.
+                // check if any promotions apply to the events or any global promotions.
                 $active_promotions = $EEM_Promotion->getAllActiveCodePromotions([
                     [
-                        'PRO_scope'  => 'Event',
-                        'PRO_global' => true,
+                        'OR' => [
+                            'PRO_global' => true,
+                            'AND' => 
+                                [
+                                    'PRO_scope'               => 'Event',
+                                    'Promotion_Object.OBJ_ID' => ['in', array_keys($events)],
+                                ],
+                        ],
                     ],
                     'limit' => 1,
                 ]);
 
-                $has_active_promotions = ! empty($active_promotions);
-
-                // if not, we check if we have for that specific event.
-                if (! $has_active_promotions) {
-                    $active_promotions = $EEM_Promotion->getAllActiveCodePromotions([
-                        [
-                            'PRO_scope' => 'Event',
-                            'Promotion_Object.OBJ_ID' => ['in', array_keys($events)],
-                        ],
-                        'limit' => 1,
-                    ]);
-
-                    $has_active_promotions = ! empty($active_promotions);
-                }
-
-                return $has_active_promotions;
+                return ! empty($active_promotions);
             }
         }
         return false;
     }
-
 
     /**
      *    _add_promotions_form_inputs

--- a/EED_Promotions.module.php
+++ b/EED_Promotions.module.php
@@ -538,8 +538,11 @@ class EED_Promotions extends EED_Module
                 $EEM_Promotion = EE_Registry::instance()->load_model('Promotion');
                 $active_promotions = $EEM_Promotion->getAllActiveCodePromotions([
                     [
-                        'PRO_scope'               => 'Event',
-                        'Promotion_Object.OBJ_ID' => ['in', array_keys($events)],
+                        'PRO_scope' => 'Event',
+                        'OR' => [
+                            'Promotion_Object.OBJ_ID' => ['in', array_keys($events)],
+                            'PRO_global'              => true,
+                        ],
                     ],
                     'limit' => 1,
                 ]);

--- a/EED_Promotions.module.php
+++ b/EED_Promotions.module.php
@@ -539,13 +539,10 @@ class EED_Promotions extends EED_Module
                 // check if any promotions apply to the events or any global promotions.
                 $active_promotions = $EEM_Promotion->getAllActiveCodePromotions([
                     [
+                        'PRO_scope' => 'Event',
                         'OR' => [
-                            'PRO_global' => true,
-                            'AND' => 
-                                [
-                                    'PRO_scope'               => 'Event',
-                                    'Promotion_Object.OBJ_ID' => ['in', array_keys($events)],
-                                ],
+                            'Promotion_Object.OBJ_ID' => ['in', array_keys($events)],
+                            'PRO_global'              => true,
                         ],
                     ],
                     'limit' => 1,

--- a/core/db_models/EEM_Promotion.model.php
+++ b/core/db_models/EEM_Promotion.model.php
@@ -166,7 +166,7 @@ class EEM_Promotion extends EEM_Soft_Delete_Base
         $promo_end_date = $this->current_time_for_query('PRO_end');
         return array(
             array(
-                'OR' => array(
+                'OR*' => array(
                     'AND'    => array(
                         'PRO_start' => array( '<=', $promo_start_date ),
                         'PRO_end'   => array( '>=', $promo_end_date ),


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
https://github.com/eventespresso/EE4-Promotions/issues/23 - ensures Promotion Code field appears on payment re-attempt from the front-end link and when only Global promo codes is used for event.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

Consider one event that has no promotion directly applied to it. If a global promotion is active, the Submit Promo Code field will be displayed at Checkout.

If no Global Promo code, the promo code field won't be displayed at checkout.

--

Consider one event that has a promotion directly applied to it and no active global promos. The submit promo code field will be displayed at Checkout.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
