### PR TITLE
Add global uses limit to promotions

### DIFF
--- a/admin/promotions/Promotions_Admin_Page.core.php
+++ b/admin/promotions/Promotions_Admin_Page.core.php
@@ -461,11 +461,13 @@ class Promotions_Admin_Page extends EE_Admin_Page
     public function promotion_details_metabox()
     {
         $promotion_uses = $this->_promotion->uses();
+        $promotion_global_uses = $this->_promotion->global_uses();
         $form_args = array(
             'promotion' => $this->_promotion,
             'promotion_global' => EEH_Form_Fields::select_input('PRO_global', $this->_yes_no_values, $this->_promotion->is_global()),
             'promotion_exclusive' => EEH_Form_Fields::select_input('PRO_exclusive', $this->_yes_no_values, $this->_promotion->is_exclusive()),
             'promotion_uses' => $promotion_uses !== EE_INF_IN_DB ? $promotion_uses : '',
+            'promotion_global_uses' => $promotion_global_uses !== EE_INF_IN_DB ? $promotion_global_uses : '',
             'price_type_selector' => $this->_get_price_type_selector(),
             'scope_selector' => $this->_get_promotion_scope_selector()
             );

--- a/admin/promotions/Promotions_Admin_Page.core.php
+++ b/admin/promotions/Promotions_Admin_Page.core.php
@@ -578,6 +578,9 @@ class Promotions_Admin_Page extends EE_Admin_Page
             'PRO_uses'        => ! empty($this->_req_data['PRO_uses'])
                 ? $this->_req_data['PRO_uses']
                 : EE_INF_IN_DB,
+            'PRO_global_uses'        => ! empty($this->_req_data['PRO_global_uses'])
+                ? $this->_req_data['PRO_global_uses']
+                : EE_INF_IN_DB,
             'PRO_accept_msg'  => ! empty($this->_req_data['PRO_accept_msg'])
                 ? $this->_req_data['PRO_accept_msg']
                 : '',

--- a/admin/promotions/templates/promotion_details_form.template.php
+++ b/admin/promotions/templates/promotion_details_form.template.php
@@ -98,6 +98,15 @@
     </tr>
     <tr>
         <th scope="row">
+            <label for="PRO_global_uses"><?php _e('Global number of Uses', 'event_espresso'); ?></label>
+        </th>
+        <td class="field-column">
+            <input type="text" class="regular-text ee-numeric" id="PRO_global_uses" name="PRO_global_uses" value="<?php echo $promotion_global_uses; ?>">
+            <p class="description"><?php _e('This determines how many times this promotion code can be applied across all scopes, this value overrides the scope uses field if set at a lower value - leave blank for no limit', 'event_espresso'); ?></p>
+        </td>
+    </tr>
+    <tr>
+        <th scope="row">
             <label for="PRO_start"><?php _e('Valid From', 'event_espresso'); ?></label>
         </th>
         <td class="field-column ee-date-column">

--- a/admin/promotions/templates/promotion_details_form.template.php
+++ b/admin/promotions/templates/promotion_details_form.template.php
@@ -71,7 +71,7 @@
     </tr>
     <tr>
         <th scope="row">
-            <label for="PRO_uses"><?php _e('Apply Promo to ALL Scope Items', 'event_espresso'); ?></label>
+            <label for="PRO_global"><?php _e('Apply Promo to ALL Scope Items', 'event_espresso'); ?></label>
         </th>
         <td class="field-column">
             <?php echo $promotion_global; ?>
@@ -80,7 +80,7 @@
     </tr>
     <tr>
         <th scope="row">
-            <label for="PRO_uses"><?php _e('Promo Is Exclusive', 'event_espresso'); ?></label>
+            <label for="PRO_exclusive"><?php _e('Promo Is Exclusive', 'event_espresso'); ?></label>
         </th>
         <td class="field-column">
             <?php echo $promotion_exclusive; ?>


### PR DESCRIPTION
See #26 

## Problem this Pull Request solves
This adds a 'Global number of Uses' field to the promotions create/edit screen, the logic for 'global uses' is already set within the add-on.

## How has this been tested
Create a promotion code and set the global uses to 1.
(Set the other uses to something higher, like 11 and it will basically be ignored with the global value set)

Use the promotion code to the uses limit and then confirm that it cant not be used again on any event it applies to.

The promotions does **not** need to be global for this global limit to apply.

Thoughts on maybe changing the name? I get the feelinh using 'Global' here might imply this needs to be global.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
