### PR TITLE
Fix events that previously had global promotions applied to them preventing new events from applying the promotion if both added to the cart

### DIFF
--- a/lib/scopes/EE_Promotion_Scope.lib.php
+++ b/lib/scopes/EE_Promotion_Scope.lib.php
@@ -687,26 +687,31 @@ abstract class EE_Promotion_Scope
                     && $promotion instanceof EE_Promotion
                     && $promotion->is_global()
                 ) {
+                    $has_promotion_object = false;
                     if (! empty($promotion_objects)) {
                         foreach ($promotion_objects as $promotion_object) {
                             if ($promotion_object instanceof EE_Promotion_Object
                                 && $promotion_object->type() === $this->slug
                                 && $promotion_object->OBJ_ID() === $object->ID()
                             ) {
-                                return $promotion_objects;
+                                $has_promotion_object = true;
+                                break;
                             }
                         }
                     }
-                    $promotion_obj = EE_Promotion_Object::new_instance(
-                        array(
-                            'PRO_ID'   => $promotion->ID(),
-                            'OBJ_ID'   => $object->ID(),
-                            'POB_type' => $this->slug,
-                            'POB_used' => 0,
-                        )
-                    );
-                    if ($promotion_obj->save()) {
-                        $promotion_objects[ $promotion_obj->ID() ] = $promotion_obj;
+                    // Object has a promotion object already.
+                    if (!$has_promotion_object) {
+                        $promotion_obj = EE_Promotion_Object::new_instance(
+                            array(
+                                'PRO_ID'   => $promotion->ID(),
+                                'OBJ_ID'   => $object->ID(),
+                                'POB_type' => $this->slug,
+                                'POB_used' => 0,
+                            )
+                        );
+                        if ($promotion_obj->save()) {
+                            $promotion_objects[ $promotion_obj->ID() ] = $promotion_obj;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Problem this Pull Request solves
When using MER, if you have a mixture of events that have had a global promotion applied to them and 'new' events in the cart then the 'new' events will not apply the global promotion when you add it to checkout, the events that previously has the promotion applied to it will.

To reproduce create a new global promotion code, the setting don't really matter, but it needs to be global.

Add 2 events to the cart (We'll use Event 1 and 2 for reference) and apply that new promotion during checkout. Finalize (Pay or invoice)

Now, re-add those events back into a new cart session (do it in the same order you did previously) and this time, add another new event that hasn't has that promotion applied to it (Event 3).

Add the promotion to the checkout and you should see that promotion apply to Event 1 and Event 2, but **not** Event 3.

This branch fixes that.

## How has this been tested
See above, also tested adding single events to the cart and confirming they work (both events that have previously had the promotion applied and 'new' events.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
