### PR TITLE
Fix event names overflowing the promotions applicable items section

### DIFF
--- a/admin/promotions/assets/promotions-details.css
+++ b/admin/promotions/assets/promotions-details.css
@@ -133,7 +133,6 @@
     padding: 1px 10px;
     min-height: 180px;
     height:auto;
-    max-height: 640px;
 }
 
 .ee-promotions-applies-to-filters .spinner {


### PR DESCRIPTION
Reported here: https://eventespresso.com/topic/promotion-events-listing-overflowing-box/?view=all#post-332871

This pr just removes the max-height css from the applicable items container.

## How has this been tested
You'll need enough events with titles that are long enough to force the applicable items selector to have a height greater than 640px, I created 12 events using this event title:

AGES 13+: AFTER SCHOOL ONLINE WEEKLY DRAWING CLASS : HOW TO DRAW PORTRAITS AND FIGURES PART {1-12}

(Obviously change the 1-12 for each individual event so you can identify them easily)

Then edit (or create) a promotion and look at 'Promotion applies to...' section.

In master it looks like this: https://monosnap.com/file/VBonSKVOTLeyBOTFwAnEaDJalQ3hpD

Switch to this branch and hard refresh within your browser, it should then look like this:  https://monosnap.com/file/6Gd1ldXF0YItrC4CLrvl0NO6QUCI1j

Check paging continues to work and the height isn't broken after switching pages.
